### PR TITLE
Update references to CNP Library as it must be fully qualified now to ensure compatibility

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ resources:
       type: github
       name: hmcts/cnp-azuredevops-libraries
       endpoint: 'hmcts'
+      ref: marty/convert-activecluster-script
 
 jobs:
   - job: Validate

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      - template: steps/charts/validate.yaml@cnp-azuredevops-libraries
+      - template: steps/charts/validate.yaml@ccnp-azuredevops-libraries
         parameters:
           chartName: nfdiv-cron
           chartReleaseName: nfdiv-cron-ci-test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pr:
       - master
 resources:
   repositories:
-    - repository: cnp-library
+    - repository: cnp-azuredevops-libraries
       type: github
       name: hmcts/cnp-azuredevops-libraries
       endpoint: 'hmcts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      - template: steps/charts/validate.yaml@ccnp-azuredevops-libraries
+      - template: steps/charts/validate.yaml@cnp-azuredevops-libraries
         parameters:
           chartName: nfdiv-cron
           chartReleaseName: nfdiv-cron-ci-test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      - template: steps/charts/validate.yaml@cnp-library
+      - template: steps/charts/validate.yaml@cnp-azuredevops-libraries
         parameters:
           chartName: nfdiv-cron
           chartReleaseName: nfdiv-cron-ci-test
@@ -37,7 +37,7 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      - template: steps/charts/release.yaml@cnp-library
+      - template: steps/charts/release.yaml@cnp-azuredevops-libraries
         parameters:
           chartName: nfdiv-cron
           chartReleaseName: nfdiv-cron


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
The centralised templates for validation and release have been updated and part of this update involves checking out the cnp-library, as this is based on the calling template i.e. this repo the only way to ensure this is always correct is to standardise the name used to reference the repo in the calling template.

As below the repository must use the full name for the repository: `cnp-azuredevops-libraries` as this is how it is referenced in the templates.
```
resources:
  repositories:
    - repository: cnp-azuredevops-libraries
      type: github
      name: hmcts/cnp-azuredevops-libraries
      endpoint: 'hmcts'
      ref: marty/convert-activecluster-script
```
